### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/Amraa1/qpay_client/security/code-scanning/1](https://github.com/Amraa1/qpay_client/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the GitHub Actions workflow. Since the `lint` job only needs to check out the code and run linter commands locally, it only requires read access to repository contents. The recommended and most restrictive setting is to specify `permissions: contents: read` at the workflow level (applies to all jobs; you could also specify it per job if different jobs need stricter granularity, but here, workflow-level is simplest and sufficient). This change goes at the top level just after the workflow name and triggers.

**How to fix (general):**  
Add the `permissions` block to the YAML, as high in the structure as logical. In this case, after the `name` and `on` keys (the workflow root).

**Specific fix:**  
Insert the following into `.github/workflows/ci.yml` after line 2 (after `on: [push, pull_request]`):

```yaml
permissions:
  contents: read
```

No new imports, methods, or variable definitions are needed; it's a YAML block insertion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
